### PR TITLE
Fix link for Livewire Goto VSCode Extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ To contribute, fork this repository, add your new resource and submit a PR. For 
 
 ## Tooling
 
-* [Livewire Goto](https://marketplace.visualstudio.com/items?itemName=lakuapik.livewire-goto) (VSCode Extension)
+* [Livewire Goto](https://marketplace.visualstudio.com/items?itemName=lennardv.livewire-goto-updated) (VSCode Extension)
 * [Livewire Docs](https://marketplace.visualstudio.com/items?itemName=austenc.livewire-docs) (VSCode Extension)
 * [Alfred Livewire Docs](https://github.com/AlexMartinFR/alfred-livewire-docs) (Alfred Workflow)
 * [Laravel Debug Bar](https://github.com/barryvdh/laravel-debugbar) (supports Livewire)


### PR DESCRIPTION
 Livewire Goto extension created by @lakuapik is archived and it is continued by @lennardv